### PR TITLE
Avoid clobbering PL_na

### DIFF
--- a/Expat/Expat.xs
+++ b/Expat/Expat.xs
@@ -1052,7 +1052,7 @@ externalEntityRef(XML_Parser parser,
 	}
 
 	if (SvTRUE(ERRSV))
-	  append_error(parser, SvPV(ERRSV, PL_na));
+	  append_error(parser, SvPV_nolen(ERRSV));
       }
     }
   }
@@ -1278,7 +1278,7 @@ XML_ParserCreate(self_sv, enc_sv, namespaces)
 	{
 	  CallbackVector *cbv;
 	  enum XML_ParamEntityParsing pep = XML_PARAM_ENTITY_PARSING_NEVER;
-	  char *enc = (char *) (SvTRUE(enc_sv) ? SvPV(enc_sv,PL_na) : 0);
+	  char *enc = (char *) (SvTRUE(enc_sv) ? SvPV_nolen(enc_sv) : 0);
 	  SV ** spp;
 
 	  Newz(320, cbv, 1, CallbackVector);
@@ -1797,7 +1797,7 @@ XML_SetBase(parser, base)
 	    b = (char *) 0;
 	  }
 	  else {
-	    b = SvPV(base, PL_na);
+	    b = SvPV_nolen(base);
 	  }
 
 	  XML_SetBase(parser, b);


### PR DESCRIPTION
We used to do SvPV(string, PL_na) in a few places.  This is not correct as it
sets the interpreter variable PL_na to the length of the string.  Conceptually,
PL_na is just a readability-improving alias for 0.  So if anyone else using the
same interpreter then does newSVpv(other_string, PL_na), an invalid read
occurs.  The test suite did not catch this because we use newSVpv(other_string,
0) everywhere.

Simply use SvPV_nolen(string) to fix this.

---

I found this via invalid reads showing up in a Gtk3 program; XML_SetBase turned out to be the culprit.  I have no idea why this did not show up in other contexts; the same program was running fine with Gtk2, for example.  I would think every XS module is affected.
